### PR TITLE
Fix lint by splitting imports

### DIFF
--- a/jules_with_api.py
+++ b/jules_with_api.py
@@ -2,9 +2,14 @@
 Combined file-poller + Flask API.
 Run:  python jules_with_api.py
 """
-import threading, time, json, datetime
+import threading
+import time
+import json
+import datetime
 from pathlib import Path
-from flask import Flask, request, jsonify
+from flask import Flask
+from flask import request
+from flask import jsonify
 
 BASE = Path(__file__).parent
 SHARED = BASE / "shared"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,4 +1,6 @@
-import subprocess, sys, pathlib
+import subprocess
+import sys
+import pathlib
 
 CLI = pathlib.Path(__file__).parent.parent / "jack_cli.py"
 


### PR DESCRIPTION
## Summary
- split multiple imports into separate lines in `jules_with_api.py`
- split multiple imports into separate lines in `tests/test_health.py`

## Testing
- `pytest -q`
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_6868158ebe688331b935c2e884a8ba9c