### PR TITLE
Add personal dashboard design

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -1,0 +1,6 @@
+# Dashboards Directory
+
+This folder contains dashboard-related code and documentation.
+
+- **personal-dashboard** – Static HTML dashboard using localStorage.
+- **dashboard-architecture.md** – Overview of the architecture and usage.

--- a/dashboards/dashboard-architecture.md
+++ b/dashboards/dashboard-architecture.md
@@ -1,0 +1,25 @@
+# Dashboard Architecture
+
+This document outlines the structure of the personal dashboard contained in this repository.
+
+## Overview
+
+The dashboard is a static web application optimized for tablet and desktop displays. It stores notes and tasks locally using the browser's `localStorage` API.
+
+### Folder Layout
+
+```
+dashboards/
+  personal-dashboard/
+    index.html
+    style.css
+    script.js
+```
+
+- **index.html** – Base markup and layout.
+- **style.css** – Responsive styles with a focus on readability and clarity.
+- **script.js** – Handles task management, note storage, and renders a mock schedule.
+
+## Usage
+
+Open `index.html` in any modern browser. Tasks and notes persist in localStorage, so data remains across page reloads.

--- a/dashboards/personal-dashboard/index.html
+++ b/dashboards/personal-dashboard/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Personal Dashboard</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>My Dashboard</h1>
+    </header>
+    <nav>
+        <ul>
+            <li><a href="#schedule">Schedule</a></li>
+            <li><a href="#tasks">Tasks</a></li>
+            <li><a href="#notes">Notes</a></li>
+        </ul>
+    </nav>
+    <main>
+        <section id="schedule" class="card">
+            <h2>Today's Schedule</h2>
+            <ul id="schedule-list"></ul>
+        </section>
+        <section id="tasks" class="card">
+            <h2>To-Do List</h2>
+            <ul id="task-list"></ul>
+            <input id="task-input" placeholder="Add task" />
+            <button id="add-task">Add</button>
+        </section>
+        <section id="notes" class="card">
+            <h2>Quick Notes</h2>
+            <textarea id="notes-area" placeholder="Write a note..."></textarea>
+        </section>
+    </main>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/dashboards/personal-dashboard/script.js
+++ b/dashboards/personal-dashboard/script.js
@@ -1,0 +1,50 @@
+(function () {
+    const schedule = [
+        { time: '9:00 AM', event: 'Morning Review' },
+        { time: '12:00 PM', event: 'Lunch with Team' },
+        { time: '3:00 PM', event: 'Project Update Meeting' },
+    ];
+
+    const scheduleList = document.getElementById('schedule-list');
+    schedule.forEach(item => {
+        const li = document.createElement('li');
+        li.textContent = `${item.time} - ${item.event}`;
+        scheduleList.appendChild(li);
+    });
+
+    const tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
+    const taskList = document.getElementById('task-list');
+    const taskInput = document.getElementById('task-input');
+    const addTaskBtn = document.getElementById('add-task');
+
+    function renderTasks() {
+        taskList.innerHTML = '';
+        tasks.forEach((task, index) => {
+            const li = document.createElement('li');
+            li.textContent = task;
+            li.addEventListener('click', () => {
+                tasks.splice(index, 1);
+                localStorage.setItem('tasks', JSON.stringify(tasks));
+                renderTasks();
+            });
+            taskList.appendChild(li);
+        });
+    }
+
+    addTaskBtn.addEventListener('click', () => {
+        if (taskInput.value.trim()) {
+            tasks.push(taskInput.value.trim());
+            taskInput.value = '';
+            localStorage.setItem('tasks', JSON.stringify(tasks));
+            renderTasks();
+        }
+    });
+
+    renderTasks();
+
+    const notesArea = document.getElementById('notes-area');
+    notesArea.value = localStorage.getItem('notes') || '';
+    notesArea.addEventListener('input', () => {
+        localStorage.setItem('notes', notesArea.value);
+    });
+})();

--- a/dashboards/personal-dashboard/style.css
+++ b/dashboards/personal-dashboard/style.css
@@ -1,0 +1,46 @@
+* {
+    box-sizing: border-box;
+}
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    background: #f5f6fa;
+    color: #333;
+}
+header {
+    background: #4a69bd;
+    color: #fff;
+    padding: 1rem;
+    text-align: center;
+}
+nav {
+    background: #f1f2f6;
+    padding: 0.5rem;
+}
+nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 1rem;
+}
+nav a {
+    text-decoration: none;
+    color: #4a69bd;
+}
+main {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1rem;
+    padding: 1rem;
+}
+.card {
+    background: #fff;
+    padding: 1rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+textarea {
+    width: 100%;
+    height: 150px;
+}


### PR DESCRIPTION
## Summary
- scaffold `dashboards` directory
- add a static personal dashboard (HTML/CSS/JS)
- document layout in `dashboard-architecture.md`
- update README for dashboards

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest -q`
- `npx eslint` *(fails: couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686aec48f31c8331940d6c84dec87abc