### PR TITLE
Add ChatGPT Google Dashboard skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 *.log
 *.swp
 *.swo
+
+# Environment files
+.env

--- a/dashboards/chatgpt-google-dashboard/README.md
+++ b/dashboards/chatgpt-google-dashboard/README.md
@@ -1,0 +1,38 @@
+# ChatGPT Google Dashboard
+
+This project integrates Google services with a ChatGPT-powered dashboard.
+
+## Folder Structure
+
+- `backend/` - Express API server
+- `frontend/` - React application
+- `docs/` - Project documentation
+
+## Setup
+
+1. Install dependencies in `backend/`:
+   ```bash
+   cd backend
+   npm init -y
+   npm install express cors dotenv googleapis openai multer
+   ```
+2. Install dependencies in `frontend/`:
+   ```bash
+   cd ../frontend
+   npm init -y
+   npm install react react-dom axios
+   ```
+3. Create `.env` in the project root:
+   ```bash
+   OPENAI_API_KEY=your-openai-api-key
+   GOOGLE_CLIENT_ID=your-google-client-id
+   GOOGLE_CLIENT_SECRET=your-google-client-secret
+   GOOGLE_REDIRECT_URI=your-google-redirect-uri
+   ```
+4. Run the backend:
+   ```bash
+   node backend/index.js
+   ```
+5. Start the frontend (e.g., with your preferred bundler).
+
+This repository is a partial setup following the migration checklist.

--- a/dashboards/chatgpt-google-dashboard/backend/index.js
+++ b/dashboards/chatgpt-google-dashboard/backend/index.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const cors = require('cors');
+require('dotenv').config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.send('Backend is running!');
+});
+
+app.listen(5000, () => {
+  console.log('Server running on port 5000');
+});

--- a/dashboards/chatgpt-google-dashboard/backend/package.json
+++ b/dashboards/chatgpt-google-dashboard/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/dashboards/chatgpt-google-dashboard/frontend/package.json
+++ b/dashboards/chatgpt-google-dashboard/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "axios": "^1.0.0"
+  },
+  "scripts": {
+    "start": "echo 'Run your preferred bundler here'",
+    "test": "echo 'No tests'"
+  }
+}

--- a/dashboards/chatgpt-google-dashboard/frontend/public/index.html
+++ b/dashboards/chatgpt-google-dashboard/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ChatGPT Google Dashboard</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="../src/index.js"></script>
+</body>
+</html>

--- a/dashboards/chatgpt-google-dashboard/frontend/src/App.js
+++ b/dashboards/chatgpt-google-dashboard/frontend/src/App.js
@@ -1,0 +1,16 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+function App() {
+  const [msg, setMsg] = useState('');
+
+  useEffect(() => {
+    axios.get('http://localhost:5000/')
+      .then(res => setMsg(res.data))
+      .catch(err => console.error(err));
+  }, []);
+
+  return <div>{msg}</div>;
+}
+
+export default App;

--- a/dashboards/chatgpt-google-dashboard/frontend/src/index.js
+++ b/dashboards/chatgpt-google-dashboard/frontend/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.js';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<React.StrictMode><App /></React.StrictMode>);


### PR DESCRIPTION
## Summary
- add initial ChatGPT Google Dashboard project under `dashboards/`
- include Express server example and React skeleton
- ignore `.env` files in git

## Testing
- `pytest -q`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d43f2dbe883319bbaad2cb2c610b7