### PR TITLE
Add Node backend for Drive and OpenAI

### DIFF
--- a/dashboards/chatgpt-google-dashboard/README.md
+++ b/dashboards/chatgpt-google-dashboard/README.md
@@ -23,16 +23,30 @@ This project integrates Google services with a ChatGPT-powered dashboard.
    npm install react react-dom axios
    ```
 3. Create `.env` in the project root:
-   ```bash
-   OPENAI_API_KEY=your-openai-api-key
-   GOOGLE_CLIENT_ID=your-google-client-id
-   GOOGLE_CLIENT_SECRET=your-google-client-secret
-   GOOGLE_REDIRECT_URI=your-google-redirect-uri
-   ```
+ ```bash
+  OPENAI_API_KEY=your-openai-api-key
+  GOOGLE_CLIENT_ID=your-google-client-id
+  GOOGLE_CLIENT_SECRET=your-google-client-secret
+  GOOGLE_REDIRECT_URI=your-google-redirect-uri
+  GOOGLE_REFRESH_TOKEN=your-refresh-token
+  GOOGLE_DRIVE_FOLDER_ID=drive-folder-id
+  ```
 4. Run the backend:
    ```bash
-   node backend/index.js
-   ```
+ node backend/index.js
+  ```
 5. Start the frontend (e.g., with your preferred bundler).
 
 This repository is a partial setup following the migration checklist.
+
+## API Endpoints
+
+The backend exposes several endpoints used by the dashboard:
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/api/upload-to-drive` | POST | Upload a file to Google Drive. Field name: `file`. |
+| `/api/process-image` | POST | Process an uploaded `image` using ChatGPT Vision. |
+| `/api/update-task-list` | POST | Update in-memory task list (`{action: 'add'|'remove', item}`). |
+| `/api/retrieve-task-list` | GET | Fetch the current task list. |
+

--- a/dashboards/chatgpt-google-dashboard/backend/index.js
+++ b/dashboards/chatgpt-google-dashboard/backend/index.js
@@ -1,15 +1,90 @@
 const express = require('express');
 const cors = require('cors');
+const multer = require('multer');
+const { google } = require('googleapis');
+const OpenAI = require('openai');
 require('dotenv').config();
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
+const upload = multer({ storage: multer.memoryStorage() });
+
+const oauth2Client = new google.auth.OAuth2(
+  process.env.GOOGLE_CLIENT_ID,
+  process.env.GOOGLE_CLIENT_SECRET,
+  process.env.GOOGLE_REDIRECT_URI
+);
+if (process.env.GOOGLE_REFRESH_TOKEN) {
+  oauth2Client.setCredentials({ refresh_token: process.env.GOOGLE_REFRESH_TOKEN });
+}
+const drive = google.drive({ version: 'v3', auth: oauth2Client });
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+let tasks = [];
+
+app.post('/api/upload-to-drive', upload.single('file'), async (req, res) => {
+  try {
+    const fileMetadata = {
+      name: req.file.originalname,
+      parents: process.env.GOOGLE_DRIVE_FOLDER_ID ? [process.env.GOOGLE_DRIVE_FOLDER_ID] : undefined,
+    };
+    const media = {
+      mimeType: req.file.mimetype,
+      body: Buffer.from(req.file.buffer),
+    };
+    const response = await drive.files.create({
+      resource: fileMetadata,
+      media,
+      fields: 'id,name',
+    });
+    res.json(response.data);
+  } catch (error) {
+    console.error('Upload error:', error.message);
+    res.status(500).json({ error: 'Failed to upload file' });
+  }
+});
+
+app.post('/api/process-image', upload.single('image'), async (req, res) => {
+  try {
+    const base64 = req.file.buffer.toString('base64');
+    const result = await openai.chat.completions.create({
+      model: 'gpt-4-vision-preview',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Extract key data from the image' },
+            { type: 'image_url', image_url: { url: `data:${req.file.mimetype};base64,${base64}` } },
+          ],
+        },
+      ],
+    });
+    res.json(result);
+  } catch (error) {
+    console.error('Vision error:', error.message);
+    res.status(500).json({ error: 'Failed to process image' });
+  }
+});
+
+app.post('/api/update-task-list', (req, res) => {
+  const { action, item } = req.body;
+  if (action === 'add' && item) tasks.push(item);
+  if (action === 'remove' && item) tasks = tasks.filter((t) => t !== item);
+  res.json({ tasks });
+});
+
+app.get('/api/retrieve-task-list', (req, res) => {
+  res.json({ tasks });
+});
+
 app.get('/', (req, res) => {
   res.send('Backend is running!');
 });
 
-app.listen(5000, () => {
-  console.log('Server running on port 5000');
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
 });

--- a/dashboards/chatgpt-google-dashboard/backend/package.json
+++ b/dashboards/chatgpt-google-dashboard/backend/package.json
@@ -4,10 +4,18 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^17.0.1",
+    "express": "^5.1.0",
+    "googleapis": "^150.0.1",
+    "multer": "^1.4.5-lts.1",
+    "openai": "^4.27.0"
+  }
 }

--- a/docs/google-drive-openai-integration.md
+++ b/docs/google-drive-openai-integration.md
@@ -1,0 +1,26 @@
+# Google Drive and OpenAI Integration
+
+This document outlines the backend endpoints that connect Google Drive and ChatGPT Vision for the dashboard.
+
+## Environment Variables
+
+Set the following keys in your `.env` file or the Render dashboard:
+
+```
+OPENAI_API_KEY=your-openai-api-key
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_REDIRECT_URI=your-google-redirect-uri
+GOOGLE_REFRESH_TOKEN=your-refresh-token
+GOOGLE_DRIVE_FOLDER_ID=drive-folder-id
+PORT=5000
+```
+
+## Endpoints
+
+- **POST `/api/upload-to-drive`** – upload a file to Google Drive. The uploaded field should be named `file`.
+- **POST `/api/process-image`** – send an `image` file to ChatGPT Vision to extract data.
+- **POST `/api/update-task-list`** – update the task list in memory by sending `{ action: 'add'|'remove', item }`.
+- **GET `/api/retrieve-task-list`** – fetch the current list of tasks.
+
+These endpoints live in `dashboards/chatgpt-google-dashboard/backend/index.js` and can be started with `npm start` from the same folder.


### PR DESCRIPTION
## Summary
- expand backend to integrate Google Drive and ChatGPT Vision
- document new environment variables and REST endpoints
- list configuration in new doc `google-drive-openai-integration.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5c3d65c8833194025d10ec98f1a2