### PR TITLE
Add a2a system roadmap

### DIFF
--- a/docs/a2a-system-implementation-roadmap.md
+++ b/docs/a2a-system-implementation-roadmap.md
@@ -1,0 +1,119 @@
+# a2a System Implementation Roadmap
+
+This document outlines a phase-by-phase strategy for migrating the JACK system to a stable, message-driven architecture.
+
+## Phase 0 – Discovery & Planning (1 week)
+
+### Roles
+- **Product Owner** – finalize scope: confirm HTTP API + broker and deprecate file-based mode.
+- **ChatGPT** – generate design diagrams, sequence flows, and Terraform boilerplate for broker service provision.
+- **All Devs** – review existing code; identify dependencies, shared libraries, and environment requirements.
+
+### Tasks
+1. Audit current Flask API and file-based messaging implementation.
+2. Confirm choice of broker technology (Redis Streams or RabbitMQ).
+3. Outline security, networking, and environment requirements.
+
+### Deliverables
+- Architecture diagram (HTTP API + broker).
+- Updated requirements doc.
+- Phase 1 sprint backlog.
+
+### Checkpoints
+- **Checkpoint 0.1** – design review call to align on architecture and confirm scope.
+
+### Testing & Hardening
+- Peer review of design artifacts.
+
+## Phase 1 – Infrastructure Provisioning (1–2 weeks)
+
+### Roles
+- **DevOps Engineer** – provision broker service and configure networking, TLS, and firewall rules.
+- **ChatGPT** – supply Terraform modules/snippets and Kubernetes/Compose templates for local development.
+- **Backend Lead** – approve resource sizing, secrets management, and cost estimates.
+
+### Tasks
+1. Deploy Redis or RabbitMQ instance in the chosen environment.
+2. Generate connection credentials and store them securely.
+3. Verify broker connectivity from the Jules API and CLI tools.
+
+### Deliverables
+- Terraform/Compose scripts.
+- Initial secrets and configuration files.
+
+### Checkpoints
+- Broker reachable from development environment.
+
+### Testing & Hardening
+- Unit test connection modules.
+- Validate TLS setup and access controls.
+
+## Phase 2 – Message API Integration (1–2 weeks)
+
+### Roles
+- **Backend Devs** – integrate broker client into Jules API.
+- **ChatGPT** – provide publish/subscribe code samples and guidance.
+- **QA** – expand tests for message flow.
+
+### Tasks
+1. Implement producer and consumer modules that interface with the broker.
+2. Update `jack_cli.py` to publish tasks and read results through the broker.
+3. Remove the file-based polling mechanism.
+
+### Deliverables
+- Updated API with broker support.
+- Revised CLI with broker communication.
+- Migration notes.
+
+### Checkpoints
+- End-to-end task submission works via the broker.
+
+### Testing & Hardening
+- Pytest coverage for publish and consume logic.
+- Load testing with concurrent clients.
+
+## Phase 3 – Stabilization & Monitoring (1 week)
+
+### Roles
+- **DevOps** – deploy monitoring for the broker and API.
+- **Backend Devs** – fix bugs discovered during integration.
+
+### Tasks
+1. Instrument broker and API with health metrics and logging.
+2. Create alerts for failed or stalled message delivery.
+3. Document recovery procedures.
+
+### Deliverables
+- Monitoring dashboards.
+- Incident response playbook.
+
+### Checkpoints
+- Successful run through a simulated outage.
+
+### Testing & Hardening
+- Chaos testing of broker restarts.
+- Security review of message payloads.
+
+## Phase 4 – Production Rollout (1 week)
+
+### Roles
+- **Product Owner** – sign off on readiness.
+- **DevOps** – deploy to production infrastructure.
+- **All Devs** – monitor and support rollout.
+
+### Tasks
+1. Tag release version and deploy the new architecture.
+2. Decommission file-based messaging artifacts.
+3. Review system performance after launch.
+
+### Deliverables
+- Final release notes.
+- Updated documentation reflecting the message-driven architecture.
+
+### Checkpoints
+- Post-launch review meeting.
+
+### Testing & Hardening
+- Regression tests with real workloads.
+- Ongoing monitoring and patching.
+

--- a/docs/cc-jack-status.md
+++ b/docs/cc-jack-status.md
@@ -62,3 +62,4 @@ The **JACK** project establishes AI-to-AI communication between:
 - ✅ CLI tool functionality verified
 - ✅ Ready for task execution and coordination
 - 🔜 Awaiting next development phase instructions
+- 📑 See `docs/a2a-system-implementation-roadmap.md` for the migration plan.

--- a/message_broker.py
+++ b/message_broker.py
@@ -1,0 +1,22 @@
+"""Minimal publish/subscribe helpers for JACK message broker."""
+from typing import Any
+
+try:
+    import redis  # type: ignore
+except Exception:  # pragma: no cover - redis optional
+    redis = None  # placeholder for environments without redis
+
+
+class Broker:
+    """Wrapper around Redis Streams for task messaging."""
+
+    def __init__(self, url: str = "redis://localhost:6379/0") -> None:
+        if redis is None:
+            raise RuntimeError("redis-py not available")
+        self.client = redis.Redis.from_url(url)
+
+    def publish(self, stream: str, message: dict[str, Any]) -> None:
+        self.client.xadd(stream, message)
+
+    def consume(self, stream: str, last_id: str = "$"):
+        return self.client.xread({stream: last_id}, block=0)


### PR DESCRIPTION
## Summary
- document migration strategy for a message‑driven architecture
- reference the roadmap from status docs
- add a minimal Redis broker helper module

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d560cf6ec83318789064614a0df45