### PR TITLE
Add test utilities and orchestrator

### DIFF
--- a/api/jules_server.py
+++ b/api/jules_server.py
@@ -1,0 +1,58 @@
+import os
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+_tasks = []
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path.startswith("/health"):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"status": "ok"}')
+        elif self.path.startswith("/tasks"):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(_tasks).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        if self.path.startswith("/add_task"):
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length).decode()
+            try:
+                data = json.loads(body)
+                task = data.get("task", "").strip()
+                if not task:
+                    raise ValueError
+            except Exception:
+                self.send_response(400)
+                self.end_headers()
+                return
+            _tasks.append({"task": task})
+            self.send_response(201)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            resp = {"message": f"queued {task!r}", "total_tasks": len(_tasks)}
+            self.wfile.write(json.dumps(resp).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def run():
+    port = int(os.environ.get("A2A_JULES_PORT", "5000"))
+    server = HTTPServer(("0.0.0.0", port), Handler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    run()

--- a/docs/jack_usage.md
+++ b/docs/jack_usage.md
@@ -12,6 +12,13 @@ status via `jack_cli.py`.
    ```
 3. On Windows, call `python jack_cli.py` explicitly.
 
+### Environment Variables
+
+`orchestrator.py` reads the following variables when launching Jules:
+
+- `A2A_JULES_PORT` – Port for the Jules server (defaults to 5000).
+- `A2A_TEST_MODE` – When set, logs are written to `orchestrator-test.log`.
+
 ## Adding Tasks
 
 Use `add` to queue a new task:

--- a/jules_api.py
+++ b/jules_api.py
@@ -39,4 +39,7 @@ def list_tasks():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000)
+    import os
+
+    port = int(os.environ.get("A2A_JULES_PORT", "5000"))
+    app.run(host="0.0.0.0", port=port)

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,42 @@
+import os
+import signal
+import subprocess
+import sys
+
+
+def main() -> None:
+    port = os.environ.get("A2A_JULES_PORT", "5000")
+    env = {**os.environ, "A2A_JULES_PORT": str(port)}
+
+    log_dir = "logs"
+    os.makedirs(log_dir, exist_ok=True)
+    log_name = "orchestrator.log"
+    if os.environ.get("A2A_TEST_MODE"):
+        log_name = "orchestrator-test.log"
+    log_path = os.path.join(log_dir, log_name)
+
+    with open(log_path, "w") as log:
+        proc = subprocess.Popen(
+            [sys.executable, "api/jules_server.py"],
+            env=env,
+            stdout=log,
+            stderr=log,
+            preexec_fn=os.setsid if os.name != "nt" else None,
+        )
+        try:
+            proc.wait()
+        except KeyboardInterrupt:
+            pass
+        finally:
+            if os.name == "nt":
+                proc.terminate()
+            else:
+                os.killpg(os.getpgid(proc.pid), signal.SIGINT)
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+if __name__ == "__main__":
+    main()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    unit: unit tests
+    integration: integration tests
+addopts = -ra

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+import os
+import signal
+import subprocess
+import sys
+
+import pytest
+
+from .utils import jules_server, wait_for_server, get_free_port
+
+
+@pytest.fixture
+def live_jules_server():
+    with jules_server() as port:
+        yield port
+
+
+@pytest.fixture
+def live_orchestrator():
+    port = get_free_port()
+    env = {**os.environ, "A2A_JULES_PORT": str(port), "A2A_TEST_MODE": "1"}
+    proc = subprocess.Popen(
+        [sys.executable, "orchestrator.py"],
+        env=env,
+        preexec_fn=os.setsid if os.name != "nt" else None,
+    )
+    try:
+        wait_for_server(f"http://127.0.0.1:{port}/health")
+        yield port
+    finally:
+        if os.name == "nt":
+            proc.terminate()
+        else:
+            os.killpg(os.getpgid(proc.pid), signal.SIGINT)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -5,6 +5,10 @@ import pathlib
 CLI = pathlib.Path(__file__).parent.parent / "jack_cli.py"
 
 
+import pytest
+
+
+@pytest.mark.unit
 def test_cli_help():
     """CLI should exit 0 when called with --help."""
     result = subprocess.run(
@@ -14,3 +18,23 @@ def test_cli_help():
     )
     assert result.returncode == 0, result.stderr
     assert "usage" in result.stdout.lower()
+
+
+@pytest.mark.integration
+def test_jules_server_health(live_jules_server):
+    import urllib.request
+
+    url = f"http://127.0.0.1:{live_jules_server}/health"
+    with urllib.request.urlopen(url) as resp:
+        data = resp.read().decode()
+    assert resp.status == 200
+
+
+@pytest.mark.integration
+def test_orchestrator_health(live_orchestrator):
+    import urllib.request
+
+    url = f"http://127.0.0.1:{live_orchestrator}/health"
+    with urllib.request.urlopen(url) as resp:
+        data = resp.read().decode()
+    assert resp.status == 200

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,57 @@
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from contextlib import contextmanager
+
+import urllib.request
+import json
+
+
+def get_free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_server(
+    url: str, timeout: float = 10, initial_delay: float = 0.1, max_delay: float = 1.0
+) -> None:
+    delay = initial_delay
+    start = time.monotonic()
+    while True:
+        try:
+            with urllib.request.urlopen(url) as resp:
+                if resp.status == 200:
+                    return
+        except Exception:
+            pass
+        if time.monotonic() - start > timeout:
+            raise RuntimeError(f"server not available at {url}")
+        time.sleep(delay)
+        delay = min(delay * 2, max_delay)
+
+
+@contextmanager
+def jules_server(redis_db: int = 15):
+    port = get_free_port()
+    env = {**os.environ, "A2A_JULES_PORT": str(port), "REDIS_DB": str(redis_db)}
+    proc = subprocess.Popen(
+        [sys.executable, "api/jules_server.py"],
+        env=env,
+        preexec_fn=os.setsid if os.name != "nt" else None,
+    )
+    try:
+        wait_for_server(f"http://127.0.0.1:{port}/health")
+        yield port
+    finally:
+        if os.name == "nt":
+            proc.terminate()
+        else:
+            os.killpg(os.getpgid(proc.pid), signal.SIGINT)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()


### PR DESCRIPTION
## Summary
- add basic Jules server without Flask under `api/`
- implement `orchestrator.py` that launches Jules respecting `A2A_JULES_PORT`
- create `tests/utils.py` with server helpers
- add pytest fixtures in `tests/conftest.py`
- extend integration tests for health checks
- document environment variables in `jack_usage.md`
- support dynamic port in `jules_api.py`

## Testing
- `pytest -m unit`
- `pytest -m integration`


------
https://chatgpt.com/codex/tasks/task_e_688023e4172883319de99974668def0d